### PR TITLE
fix: Result.combine ignoring null and undefined results

### DIFF
--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -1,5 +1,9 @@
 import { Result, Ok, Err } from '../index';
-import { shouldEventuallyOk, shouldEventuallyErr } from './helper';
+import {
+  shouldEventuallyOk,
+  shouldEventuallyErr,
+  shouldBeAssignable,
+} from './helper';
 
 class Error1 extends Error {
   name = 'Error1' as const;
@@ -56,4 +60,29 @@ test('Result combine of mixed types per Result returns expected result', (done) 
   ]);
 
   shouldEventuallyOk(mapped, ['return-type', 5], done);
+});
+
+test('Result.combine of results with possibly undefined values preserves possibly undefined values', (done) => {
+  const result = Result.combine([
+    Ok.of<string | undefined>(undefined),
+    Ok.of<number | undefined>(5),
+  ]);
+
+  shouldBeAssignable(result, Ok.of<[string, number]>(['hello', 1]));
+  shouldBeAssignable(
+    result,
+    Ok.of<[undefined, undefined]>([undefined, undefined])
+  );
+  shouldEventuallyOk(result, [undefined, 5], done);
+});
+
+test('Result.combine of results with nullable values preserves nullable values', (done) => {
+  const result = Result.combine([
+    Ok.of<string | null>(null),
+    Ok.of<number | null>(5),
+  ]);
+
+  shouldBeAssignable(result, Ok.of<[string, number]>(['hello', 1]));
+  shouldBeAssignable(result, Ok.of<[null, null]>([null, null]));
+  shouldEventuallyOk(result, [null, 5], done);
 });

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -41,5 +41,36 @@ async function shouldEventuallyErr<TValue>(
   }
 }
 
+/**
+ * Check if two values are compatible, can `value` be assigned to `to`.
+ *
+ * Most of the time we can verify the type of an operation by providing
+ * an explicit expected type, e.g.
+ *
+ * ```ts
+ * const action = () => 1
+ * const actual: string = action()
+ * ```
+ *
+ * The test will fail type checks, because `number` cannot be assigned to `string`.
+ * However, when the expected type is a superset of the returned type, e.g.
+ *
+ * ```ts
+ * const actual: string | number = action()
+ * ```
+ *
+ * Such a test won't ensure that `action()` returns exactly `string | number`,
+ * since `number` can be assigned to `string | number`.
+ *
+ * Instead we can infer the `actual` value and check if we can assign all
+ * our expected types to it.
+ *
+ * ```ts
+ * const actual = action()
+ *
+ * shouldBeAssignable(actual, 2)  // pass
+ * shouldBeAssignable(actual, "") // fail, string cannot be assigned to number
+ * ```
+ */
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function shouldBeAssignable<T>(_to: T, _value: T) {}

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { Result } from '../types/result-helpers';
 
-export { shouldEventuallyOk, shouldEventuallyErr };
+export { shouldEventuallyOk, shouldEventuallyErr, shouldBeAssignable };
 
 async function shouldEventuallyOk<TValue>(
   result: Result<unknown, unknown>,
@@ -40,3 +40,6 @@ async function shouldEventuallyErr<TValue>(
     done(`Err result expected (${value}), got Ok result`);
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function shouldBeAssignable<T>(_to: T, _value: T) {}

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -61,17 +61,9 @@ type ExtractErrTypes<T extends readonly ResultType<unknown, unknown>[]> = {
 type ExtractOkFromUnion<T extends ResultType<unknown, unknown>> = T extends Ok<
   infer V
 >
-  ? // eslint-disable-next-line @typescript-eslint/ban-types
-    V extends {} // filter out "unknown" values
-    ? V
-    : never
+  ? V
   : never;
 
 // need to be separated generic type to run it for every element of union T separately
 type ExtractErrFromUnion<T extends ResultType<unknown, unknown>> =
-  T extends Err<infer E>
-    ? // eslint-disable-next-line @typescript-eslint/ban-types
-      E extends {} // filter out "unknown" values
-      ? E
-      : never
-    : never;
+  T extends Err<infer E> ? E : never;


### PR DESCRIPTION
At the moment when you combine results that might include `null` or `undefined` they are being filtered out from the combined result, which means TypeScript won't catch problems with possibly undefined or null values down the chain.

```ts
Result.combine([
  Ok.of<string | null>(null),
  Ok.of<number | undefined>(undefined),
])
```

infers to `Ok<[string, number]>` instead of `Ok<[string | null, number | undefined]>`

This PR fixes that by removing a `T extends {} ? T : never` check, which was filtering out `null` and `undefined`. @wiktor-obrebski this check had a comment suggesting it was important, but I couldn't figure out why, so it might need some additional testing. 