### PR TITLE
feat: allow passing a promise to Result.from and Result.combine

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -25,7 +25,12 @@ const Result: ResultNamespace = {
   },
 
   combine(results) {
-    const wrappersPromise = Promise.all(results.map((res) => res.__value));
+    const resultsPromise = Promise.resolve(results);
+
+    const wrappersPromise = resultsPromise.then((results) =>
+      Promise.all(results.map((res) => res.__value))
+    );
+
     const resultPromise = wrappersPromise.then((wrappers) => {
       const values = [];
       for (const wrapper of wrappers) {

--- a/src/result.ts
+++ b/src/result.ts
@@ -8,9 +8,12 @@ import { ResultNamespace, OkNamespace, ErrNamespace } from './types/result';
 export { Ok, OkNamespace, Err, ErrNamespace, Result, ResultNamespace };
 
 const Result: ResultNamespace = {
-  from(factory) {
-    const factoryPromise = Promise.resolve(factory());
-    const resultWrapperPromise = factoryPromise.then((result) => {
+  from(value) {
+    const valuePromise = Promise.resolve(
+      typeof value === 'function' ? value() : value
+    );
+
+    const resultWrapperPromise = valuePromise.then((result) => {
       if (isResult(result)) {
         return result.__value;
       } else {

--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -57,3 +57,42 @@ test('Result combine of mixed types per Result returns expected result', (done) 
 
   shouldEventuallyOk(mapped, ['return-type', 5], done);
 });
+
+suite('Result.combine of results promise', () => {
+  test('returns mapped results of promise of ok results', (done) => {
+    const results = Promise.all([Ok.of(5), Ok.of('hello')]);
+    const mapped: Ok<[number, string]> = Result.combine(results);
+
+    shouldEventuallyOk(mapped, [5, 'hello'], done);
+  });
+
+  test('returns mapped results of promise of err results', (done) => {
+    const err1 = new Error1();
+    const err2 = new Error2();
+    const results = Promise.all([
+      Err.of(err1) as Result<string, Error1>,
+      Err.of(err2) as Result<number, Error2>,
+    ]);
+
+    const mapped: Result<[string, number], Error1 | Error2> =
+      Result.combine(results);
+
+    shouldEventuallyErr(mapped, err1, done);
+  });
+
+  test('returns mapped result of promise of mixed results', (done) => {
+    const err1 = new Error1();
+    const err2 = new Error2();
+    const results = Promise.all([
+      Ok.of('hello'),
+      Err.of(err1) as Result<string, Error1>,
+      Ok.of(5),
+      Err.of(err2) as Result<number, Error2>,
+    ]);
+
+    const mapped: Result<[string, string, number, number], Error1 | Error2> =
+      Result.combine(results);
+
+    shouldEventuallyErr(mapped, err1, done);
+  });
+});

--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -96,3 +96,41 @@ suite('Result.from of single Ok result factory', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 });
+
+suite('Result.from of result promise', () => {
+  test('returns mapped result with promise of a plain value', (done) => {
+    const mapped: Ok<number> = Result.from(Promise.resolve(5));
+
+    shouldEventuallyOk(mapped, 5, done);
+  });
+
+  test('returns mapped result with promise of ok result', (done) => {
+    const mapped: Ok<number> = Result.from(Promise.resolve(Ok.of(5)));
+
+    shouldEventuallyOk(mapped, 5, done);
+  });
+
+  test('returns mapped result with promise of err result', (done) => {
+    const err = new Error1();
+
+    const mapped: Err<Error1> = Result.from(Promise.resolve(Err.of(err)));
+
+    shouldEventuallyErr(mapped, err, done);
+  });
+
+  test('returns mapped result with promise of mixed results', (done) => {
+    const mapped: Result<number, Error1> = Result.from(
+      Promise.resolve(Ok.of(5)) as Promise<Result<number, Error1>>
+    );
+
+    shouldEventuallyOk(mapped, 5, done);
+  });
+
+  test('returns mapped result with promise of mixed plain values and err results', (done) => {
+    const mapped: Result<number, Error1> = Result.from(
+      Promise.resolve(5) as Promise<number | Result<never, Error1>>
+    );
+
+    shouldEventuallyOk(mapped, 5, done);
+  });
+});

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -21,7 +21,7 @@ interface ResultNamespace {
    * @returns Result Ok of all input Ok values, or Err Result of one of provided Err values.
    */
   combine<T extends readonly ResultType<unknown, unknown>[]>(
-    results: [...T]
+    results: [...T] | Promise<[...T]>
   ): SpreadErrors<ResultType<ExtractOkTypes<T>, ExtractErrTypes<T>[number]>>;
 }
 

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -9,7 +9,7 @@ import type {
 export type { ResultNamespace, OkNamespace, ErrNamespace };
 
 interface ResultNamespace {
-  from<R>(factory: () => R): MapFromResult<R>;
+  from<R>(factory: Promise<R> | (() => R)): MapFromResult<R>;
 
   /**
    * Combine provided Results list into single Result. If all provided Results


### PR DESCRIPTION
Added support for passing a promise to `Result.from`, so that we can just

```ts
Result.from(someAsyncLogic()).map(...)
```

instead of 

```ts
Result.from(() => someAsyncLogic()).map(...)
```

Similarly, added support for passing a promise of results to `Result.combine`

```ts
Result.combine(Promise.all([
  someAsyncLogic(),
  someAsyncLogic(),
  someAsyncLogic(),
])).map(([foo, bar, baz]) => { ... })
```

instead of 

```ts
Result.combine([
  Result.from(() => someAsyncLogic()),
  Result.from(() => someAsyncLogic()),
  Result.from(() => someAsyncLogic()),
]).map(([foo, bar, baz]) => { ... })
```

ideally we could just

```ts
Result.combine([
  someAsyncLogic(),
  someAsyncLogic(),
  someAsyncLogic(),
]).map(([foo, bar, baz]) => { ... })
```

but I haven't figured out yet how to do that :wink: 