### PR TITLE
Bump to 0.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "type-safe-errors",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "type-safe-errors",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "type-safe-errors",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Simple type-safe errors for TypeScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/result.ts
+++ b/src/result.ts
@@ -35,7 +35,7 @@ const Result: ResultNamespace = {
       return { isError: false, value: values };
     });
 
-    return commonResultFactory(resultPromise);
+    return commonResultFactory(resultPromise) as any;
   },
 };
 


### PR DESCRIPTION
- support for undefined/null results in `Result.combine` API