### PR TITLE
Fix `Result.from` to handle sync and async throws

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -9,14 +9,16 @@ export { Ok, OkNamespace, Err, ErrNamespace, Result, ResultNamespace };
 
 const Result: ResultNamespace = {
   from(factory) {
-    const factoryPromise = Promise.resolve(factory());
-    const resultWrapperPromise = factoryPromise.then((result) => {
-      if (isResult(result)) {
-        return result.__value;
-      } else {
-        return resultWrapperFactory(result, false);
-      }
-    });
+    const factoryPromise = Promise.resolve().then(factory);
+    const resultWrapperPromise = factoryPromise
+      .then((result) => {
+        if (isResult(result)) {
+          return result.__value;
+        } else {
+          return resultWrapperFactory(result, false);
+        }
+      })
+      .catch((err) => resultWrapperFactory(err, true));
 
     return commonResultFactory(resultWrapperPromise) as any;
   },

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 import { Result } from '../types/result-helpers';
 
-export { shouldEventuallyOk, shouldEventuallyErr, shouldBeAssignable };
+export {
+  shouldEventuallyOk,
+  shouldEventuallyErr,
+  shouldEventuallyReject,
+  shouldBeAssignable,
+};
 
 async function shouldEventuallyOk<TValue>(
   result: Result<unknown, unknown>,
@@ -38,6 +43,19 @@ async function shouldEventuallyErr<TValue>(
     }
   } else {
     done(`Err result expected (${value}), got Ok result`);
+  }
+}
+
+async function shouldEventuallyReject<TValue>(
+  result: Result<unknown, unknown>,
+  value: TValue,
+  done: (err?: any) => void
+): Promise<void> {
+  try {
+    await result.unsafePromise();
+    done(`Reject promise result expected (${value}), but promise resolve`);
+  } catch (err) {
+    done();
   }
 }
 

--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -1,11 +1,11 @@
 import { Result, Ok, Err } from '../index';
-import { shouldEventuallyOk, shouldEventuallyErr } from './helper';
+import { shouldEventuallyOk, shouldEventuallyErr, shouldEventuallyReject } from './helper';
 
 class Error1 {
   name = 'Error1' as const;
 }
 
-suite('Result.from of single Ok result factory', () => {
+suite('Result.from of an result factory', () => {
   test('returns maped result for mapper with plain return', (done) => {
     const mapped: Ok<'test-return'> = Result.from(() => {
       return 'test-return' as const;
@@ -94,5 +94,21 @@ suite('Result.from of single Ok result factory', () => {
     });
 
     shouldEventuallyOk(mapped, 'test-ok', done);
+  });
+
+  test('returns rejected result for throwing async mapper', (done) => {
+    const mapped: Result<never, never> = Result.from(async () => {
+      throw new Error('Something goes wrong');
+    });
+
+    shouldEventuallyReject(mapped, 'Something goes wrong', done);
+  });
+
+  test('returns rejected result for throwing sync mapper', (done) => {
+    const mapped: Result<never, never> = Result.from(() => {
+      throw new Error('Something goes wrong');
+    });
+
+    shouldEventuallyReject(mapped, 'Something goes wrong', done);
   });
 });


### PR DESCRIPTION
Before throwed error in `Result.from` mapping function behaves unexpectedly.
For sync mapper, like `Result.from(() => { throw new Error(); })` the call rethrowed the error instantly, without creating any `Result`. 
For sync, it bubble it as successful result, which worker in expected way more by accident than by design.

This code add missing tests for such cases in fix the bug.