### PR TITLE
Feature/unknown error

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -408,7 +408,7 @@ const fetchDataOrErrorResult = Result.from(async () => {
 });
 ```
 
-Note: If an unexpected error is thrown within the `resultFactory` function, it will be wrapped in an `UnknownError` and passed to the `mapErr` or `mapAnyErr` function if they are in the chain. If not handled, it will result in a rejected promise.
+Note: If an unexpected error is thrown within the `resultFactory` function, it will be wrapped in an `UnknownError` and passed to the `mapErr` or `mapAnyErr` function if they are in the chain. If not handled, it will result in a rejected promise when using either [ok.promise()](#okpromise) or [result.unsafePromise()](#resultunsafePromise).
 
 ```ts
 import { Result, UnknownError } from 'type-safe-errors';
@@ -544,6 +544,10 @@ const okOfNumber5 = originOk.mapAnyErr(err => 123);
 
 ### UnknownError
 `UnknownError` is a special error class used to wrap unexpected errors that are thrown within the `map`, `mapErr`, `mapAnyErr`, or `Result.from` context. It has a `cause` property that contains the original error.
+
+`UnknownError` is the only error which you don't need to handle before using [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). The reason is simple even if you do [result.mapErr(ErrorClass, callback)](#resultmaperrerrorclass-callback) with `UnknownError` as first parameter your code could throw an error in handler function anyway. So, you can never be sure that an unexpected error not happen and the library API reflects this.
+
+`UnknownError` is the only error that you're not required to handle before utilizing a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This is because, even if you invoke [`result.mapErr(ErrorClass, callback)`](#resultmaperrerrorclass-callback) with `UnknownError` as the first parameter, your handler function might still throw an error. Thus, you can never be entirely confident that an unexpected error won't occur, and the library's API acknowledges this reality.
 
 Examples:
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -545,8 +545,6 @@ const okOfNumber5 = originOk.mapAnyErr(err => 123);
 ### UnknownError
 `UnknownError` is a special error class used to wrap unexpected errors that are thrown within the `map`, `mapErr`, `mapAnyErr`, or `Result.from` context. It has a `cause` property that contains the original error.
 
-`UnknownError` is the only error which you don't need to handle before using [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). The reason is simple even if you do [result.mapErr(ErrorClass, callback)](#resultmaperrerrorclass-callback) with `UnknownError` as first parameter your code could throw an error in handler function anyway. So, you can never be sure that an unexpected error not happen and the library API reflects this.
-
 `UnknownError` is the only error that you're not required to handle before utilizing a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). This is because, even if you invoke [`result.mapErr(ErrorClass, callback)`](#resultmaperrerrorclass-callback) with `UnknownError` as the first parameter, your handler function might still throw an error. Thus, you can never be entirely confident that an unexpected error won't occur, and the library's API acknowledges this reality.
 
 Examples:

--- a/src/common-result.ts
+++ b/src/common-result.ts
@@ -10,7 +10,7 @@ export {
   isResult,
   commonResultFactory,
   resultWrapperFactory,
-  unknownErrorWrapperFactory,
+  wrapResultFactory,
 };
 
 class UnknownError extends Error implements UnknownErrorType {
@@ -34,16 +34,7 @@ const CommonResultPrototype: CommonResult<unknown> = {
         return wrapper;
       }
 
-      return Promise.resolve()
-        .then(() => mapper(wrapper.value as any))
-        .then((newValue) => {
-          if (isResult(newValue)) {
-            return newValue.__value;
-          } else {
-            return resultWrapperFactory(newValue, false);
-          }
-        })
-        .catch(unknownErrorWrapperFactory);
+      return wrapResultFactory(() => mapper(wrapper.value as any));
     });
     return commonResultFactory(newValWrapperPromise) as any;
   },
@@ -54,16 +45,7 @@ const CommonResultPrototype: CommonResult<unknown> = {
         return wrapper;
       }
 
-      return Promise.resolve()
-        .then(() => mapper(wrapper.value as any))
-        .then((newValue) => {
-          if (isResult(newValue)) {
-            return newValue.__value;
-          } else {
-            return resultWrapperFactory(newValue, false);
-          }
-        })
-        .catch(unknownErrorWrapperFactory);
+      return wrapResultFactory(() => mapper(wrapper.value as any));
     });
     return commonResultFactory(newValWrapperPromise) as any;
   },
@@ -74,16 +56,7 @@ const CommonResultPrototype: CommonResult<unknown> = {
         return wrapper;
       }
 
-      return Promise.resolve()
-        .then(() => mapper(wrapper.value as any))
-        .then((newValue) => {
-          if (isResult(newValue)) {
-            return newValue.__value;
-          } else {
-            return resultWrapperFactory(newValue, false);
-          }
-        })
-        .catch(unknownErrorWrapperFactory);
+      return wrapResultFactory(() => mapper(wrapper.value as any));
     });
     return commonResultFactory(newValWrapperPromise) as any;
   },
@@ -128,4 +101,13 @@ function resultWrapperFactory<TErrorOrValue>(
 
 function unknownErrorWrapperFactory(err: unknown): ResultWrapper<UnknownError> {
   return { value: new UnknownError(err), isError: true };
+}
+
+function wrapResultFactory(valueFactory: () => unknown) {
+  return Promise.resolve()
+    .then(valueFactory)
+    .then((result) =>
+      isResult(result) ? result.__value : resultWrapperFactory(result, false)
+    )
+    .catch(unknownErrorWrapperFactory);
 }

--- a/src/common-result.ts
+++ b/src/common-result.ts
@@ -16,8 +16,11 @@ export {
 class UnknownError extends Error implements UnknownErrorType {
   name = '__UnknownError' as const;
 
-  constructor(public errCause: unknown) {
+  cause?: unknown;
+
+  constructor(cause: unknown) {
     super();
+    this.cause = cause;
   }
 }
 
@@ -90,7 +93,7 @@ const CommonResultPrototype: CommonResult<unknown> = {
       if (wrapper.isError) {
         return Promise.reject(
           wrapper.value instanceof UnknownError
-            ? wrapper.value.errCause
+            ? wrapper.value.cause
             : wrapper.value
         );
       }

--- a/src/common-result.ts
+++ b/src/common-result.ts
@@ -64,11 +64,11 @@ const CommonResultPrototype: CommonResult<unknown> = {
   unsafePromise() {
     return this.__value.then((wrapper) => {
       if (wrapper.isError) {
-        return Promise.reject(
+        const originErr =
           wrapper.value instanceof UnknownError
             ? wrapper.value.cause
-            : wrapper.value
-        );
+            : wrapper.value;
+        return Promise.reject(originErr);
       }
 
       return Promise.resolve(wrapper.value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import type {
 
 import { Result as ResultVal, Ok as OkVal, Err as ErrVal } from './result';
 
+export { UnknownError } from './common-result';
+
 export const Result = ResultVal;
 export type Result<TValue, TError> = ResultType<TValue, TError>;
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,8 +1,7 @@
 import {
   commonResultFactory,
   resultWrapperFactory,
-  unknownErrorWrapperFactory,
-  isResult,
+  wrapResultFactory,
 } from './common-result';
 import { ResultNamespace, OkNamespace, ErrNamespace } from './types/result';
 
@@ -10,16 +9,7 @@ export { Ok, OkNamespace, Err, ErrNamespace, Result, ResultNamespace };
 
 const Result: ResultNamespace = {
   from(factory) {
-    const factoryPromise = Promise.resolve().then(factory);
-    const resultWrapperPromise = factoryPromise
-      .then((result) => {
-        if (isResult(result)) {
-          return result.__value;
-        } else {
-          return resultWrapperFactory(result, false);
-        }
-      })
-      .catch(unknownErrorWrapperFactory);
+    const resultWrapperPromise = wrapResultFactory(factory);
 
     return commonResultFactory(resultWrapperPromise) as any;
   },

--- a/src/result.ts
+++ b/src/result.ts
@@ -15,8 +15,11 @@ const Result: ResultNamespace = {
   },
 
   combine(results) {
-    const wrappersPromise = Promise.all(results.map((res) => res.__value));
-    const resultPromise = wrappersPromise.then((wrappers) => {
+    const wrapperPromises = results.map((res) =>
+      Promise.resolve(res).then((v) => v.__value)
+    );
+
+    const resultPromise = Promise.all(wrapperPromises).then((wrappers) => {
       const values = [];
       for (const wrapper of wrappers) {
         if (wrapper.isError) {

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,6 +1,7 @@
 import {
   commonResultFactory,
   resultWrapperFactory,
+  unknownErrorWrapperFactory,
   isResult,
 } from './common-result';
 import { ResultNamespace, OkNamespace, ErrNamespace } from './types/result';
@@ -18,7 +19,7 @@ const Result: ResultNamespace = {
           return resultWrapperFactory(result, false);
         }
       })
-      .catch((err) => resultWrapperFactory(err, true));
+      .catch(unknownErrorWrapperFactory);
 
     return commonResultFactory(resultWrapperPromise) as any;
   },

--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -62,7 +62,7 @@ test('Result combine of mixed types per Result returns expected result', (done) 
   shouldEventuallyOk(mapped, ['return-type', 5], done);
 });
 
-test('Result combine of mixed types per Result and Result promises returns expected result', (done) => {
+test('Result combine should return expected result for async/sync mixed results input', (done) => {
   const mixedResult1 = Ok.of('return-type') as Err<Error1> | Ok<'return-type'>;
   const mixedAsycnResult = Promise.resolve(
     Ok.of('return-type2') as Err<Error2> | Ok<'return-type2'>

--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -62,6 +62,25 @@ test('Result combine of mixed types per Result returns expected result', (done) 
   shouldEventuallyOk(mapped, ['return-type', 5], done);
 });
 
+test('Result combine of mixed types per Result and Result promises returns expected result', (done) => {
+  const mixedResult1 = Ok.of('return-type') as Err<Error1> | Ok<'return-type'>;
+  const mixedAsycnResult = Promise.resolve(
+    Ok.of('return-type2') as Err<Error2> | Ok<'return-type2'>
+  );
+
+  const mapped: Result<
+    ['return-type', number, number, 'return-type2'],
+    Error1 | Error2
+  > = Result.combine([
+    mixedResult1,
+    Ok.of(5),
+    Promise.resolve(Ok.of(5)),
+    mixedAsycnResult,
+  ]);
+
+  shouldEventuallyOk(mapped, ['return-type', 5, 5, 'return-type2'], done);
+});
+
 test('Result.combine of results with possibly undefined values preserves possibly undefined values', (done) => {
   const result = Result.combine([
     Ok.of<string | undefined>(undefined),

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -63,7 +63,7 @@ async function shouldEventuallyUnknownErr(
   try {
     expect(wrapper.value).instanceOf(UnknownError);
     if (wrapper.value instanceof UnknownError) {
-      expect(wrapper.value.errCause).to.equal(err);
+      expect(wrapper.value.cause).to.equal(err);
       return done();
     }
 

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -1,10 +1,13 @@
 import { expect } from 'chai';
+
 import { Result } from '../types/result-helpers';
+import { UnknownError } from '../common-result';
 
 export {
   shouldEventuallyOk,
   shouldEventuallyErr,
   shouldEventuallyReject,
+  shouldEventuallyUnknownErr,
   shouldBeAssignable,
 };
 
@@ -43,6 +46,30 @@ async function shouldEventuallyErr<TValue>(
     }
   } else {
     done(`Err result expected (${value}), got Ok result`);
+  }
+}
+
+async function shouldEventuallyUnknownErr(
+  result: Result<unknown, unknown>,
+  err: unknown,
+  done: (err?: any) => void
+): Promise<void> {
+  const wrapper = await result.__value;
+
+  if (!wrapper.isError) {
+    done(`UnknownError Err result expected, got Ok result`);
+  }
+
+  try {
+    expect(wrapper.value).instanceOf(UnknownError);
+    if (wrapper.value instanceof UnknownError) {
+      expect(wrapper.value.errCause).to.equal(err);
+      return done();
+    }
+
+    done('Unexpected tests path, should throw before');
+  } catch (err) {
+    done(err);
   }
 }
 

--- a/src/test/map.test.ts
+++ b/src/test/map.test.ts
@@ -150,9 +150,11 @@ suite('Result map of Err result should not be affected by', () => {
   const result = Err.of(errInstance);
 
   test('mapper with plain return', (done) => {
-    const mapped: Err<Error1> = result.map((_value: never) => {
-      return 'test-return' as const;
-    });
+    const mapped: Ok<'test-return'> | Err<Error1> = result.map(
+      (_value: never) => {
+        return 'test-return' as const;
+      }
+    );
 
     shouldEventuallyErr(mapped, errInstance, done);
   });
@@ -886,7 +888,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
   test('rejects with throwed exception if mapper throws an exception', (done) => {
     const err4 = new Error3();
 
-    const mapped: Ok<number> | Err<Error1> | Err<Error2> = result.map(
+    const mapped: Ok<never> | Err<Error1 | Error2> = result.map(
       (_val: number | string) => {
         if (true) {
           throw err4;

--- a/src/test/map.test.ts
+++ b/src/test/map.test.ts
@@ -132,6 +132,24 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyUnknownErr(mapped, err4, done);
   });
 
+  test('returns maped value for UnknownError err when infering type', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Ok.of(5).map((_val) => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
+  });
+
   test('rejects with throwed exception if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
@@ -965,6 +983,24 @@ suite('mapAnyErr', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
+  test('returns maped value for UnknownError err when infering type', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Err.of(new Error1()).mapAnyErr(() => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
+  });
+
   test('returns maped UnknownError result if mapper throws an exception', (done) => {
     const err1 = new Error1();
     const err4 = new Error2();
@@ -1088,18 +1124,38 @@ suite('mapErr', () => {
     }
   );
 
+  test('returns maped value for UnknownError err when infering type', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Err.of(new Error1()).mapErr(Error1, () => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
+  });
+
   test('returns maped value for UnknownError err', (done) => {
     const err4 = new Error('Something happened');
 
     const result = Result.from(() => {
       throw err4;
-    }) as Err<Error1> | Ok<number>;
+    }) as Ok<number>;
 
-    const mapped: Ok<number> | Ok<'mapped-unknown-err-result'> | Err<Error1> =
-      result.mapErr(UnknownError, (err: UnknownError) => {
+    const mapped: Ok<number> | Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
         expect(err.cause).to.equal(err4);
         return 'mapped-unknown-err-result' as const;
-      });
+      }
+    );
 
     shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
   });

--- a/src/test/map.test.ts
+++ b/src/test/map.test.ts
@@ -1095,7 +1095,7 @@ suite('mapErr', () => {
 
     const mapped: Ok<number> | Ok<'mapped-unknown-err-result'> | Err<Error1> =
       result.mapErr(UnknownError, (err: UnknownError) => {
-        expect(err.errCause).to.equal(err4);
+        expect(err.cause).to.equal(err4);
         return 'mapped-unknown-err-result' as const;
       });
 

--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -1,5 +1,9 @@
 import { Result, Ok, Err } from '../index';
-import { shouldEventuallyOk, shouldEventuallyErr, shouldEventuallyReject } from './helper';
+import {
+  shouldEventuallyOk,
+  shouldEventuallyErr,
+  shouldEventuallyReject,
+} from './helper';
 
 class Error1 {
   name = 'Error1' as const;

--- a/src/types/common-result.ts
+++ b/src/types/common-result.ts
@@ -9,6 +9,8 @@ import type {
   MapAnyErrResult,
   InferErr,
   SpreadErrors,
+  Err,
+  UnknownError,
 } from './result-helpers';
 
 export type { CommonResult, ResultWrapper };
@@ -22,7 +24,11 @@ interface CommonResult<TErrorOrValue> {
     mapper: OkMapper<U, R>
   ): SpreadErrors<MapOkResult<SpreadErrors<U>, R>>;
 
-  mapErr<U extends Result<unknown, unknown>, R, E extends InferErr<U>>(
+  mapErr<
+    U extends Result<unknown, unknown>,
+    R,
+    E extends InferErr<U> | UnknownError
+  >(
     this: U,
     ErrorClass: AClass<E>,
     mapper: (err: E) => R
@@ -30,7 +36,7 @@ interface CommonResult<TErrorOrValue> {
 
   mapAnyErr<U extends Result<unknown, unknown>, R>(
     this: U,
-    mapper: ErrMapper<U, R>
+    mapper: ErrMapper<U | Err<UnknownError>, R>
   ): SpreadErrors<MapAnyErrResult<SpreadErrors<U>, R>>;
 
   unsafePromise<U extends Result<unknown, unknown>>(

--- a/src/types/common-result.ts
+++ b/src/types/common-result.ts
@@ -1,6 +1,6 @@
 import type {
   Result,
-  AClass,
+  Constructor,
   OkMapper,
   MapOkResult,
   InferOk,
@@ -30,7 +30,7 @@ interface CommonResult<TErrorOrValue> {
     E extends InferErr<U> | UnknownError
   >(
     this: U,
-    ErrorClass: AClass<E>,
+    ErrorClass: Constructor<E>,
     mapper: (err: E) => R
   ): SpreadErrors<MapErrResult<SpreadErrors<U>, R, E>>;
 

--- a/src/types/common-result.ts
+++ b/src/types/common-result.ts
@@ -49,7 +49,7 @@ interface CommonResult<TErrorOrValue> {
    * function you need first handle all known `Err`` result values.
    * It is possible that it return rejected promise for unknown exceptions.
    * @returns promise of current Result value - fulfilled if the value is Ok,
-   *          rejected if the was an exception throw in the mapping chain
+   *          rejected if there was an exception thrown anywhere in the mapping chain
    */
   promise<U extends Result<unknown, unknown>>(
     this: U

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -14,7 +14,14 @@ export type {
   MapAnyErrResult,
   InferErr,
   SpreadErrors,
+  UnknownError,
 };
+
+interface UnknownError extends Error {
+  name: '__UnknownError';
+
+  errCause: unknown;
+}
 
 type Result<TValue, TError> = Ok<TValue> | Err<TError>;
 
@@ -60,7 +67,11 @@ interface Subresult {
    * @param mapper the function used to map the current Err result, can be async
    * @returns new Result, mapped if current Result is Err of specific class, left unchanged otherwise
    */
-  mapErr<U extends Result<unknown, unknown>, R, E extends InferErr<U>>(
+  mapErr<
+    U extends Result<unknown, unknown>,
+    R,
+    E extends InferErr<U> | UnknownError
+  >(
     this: U,
     ErrorClass: AClass<E>,
     mapper: (err: E) => R
@@ -99,7 +110,7 @@ type InferErr<U extends Result<unknown, unknown>> = U extends Err<infer T>
   : never;
 
 type ErrMapper<U extends Result<unknown, unknown>, R> = (
-  value: InferErr<U>
+  value: InferErr<U> | UnknownError
 ) => R;
 
 type MapFromResult<R> = R extends Result<unknown, unknown>

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -20,7 +20,7 @@ export type {
 interface UnknownError extends Error {
   name: '__UnknownError';
 
-  errCause: unknown;
+  cause?: unknown;
 }
 
 type Result<TValue, TError> = Ok<TValue> | Err<TError>;

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -8,9 +8,15 @@ interface UnknownError extends Error {
   cause?: unknown;
 }
 
-type Result<TValue, TError> =
+type BaseResult<TValue, TError> =
   | (TValue extends never ? never : Ok<TValue>)
   | (TError extends never ? never : Err<TError>);
+
+type Result<TValue, TError> = BaseResult<TValue, TError> extends never
+  ? // mapping result should never be never, it can be Ok of never if there is
+    // no other Result's known
+    Ok<never>
+  : BaseResult<TValue, TError>;
 
 type Ok<TValue> = Subresult & {
   readonly __value: Promise<ResultWrapper<TValue>>;

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -2,7 +2,7 @@ import type { ResultWrapper } from './common-result';
 
 export type {
   Result,
-  AClass,
+  Constructor,
   Ok,
   OkMapper,
   MapFromResult,
@@ -73,7 +73,7 @@ interface Subresult {
     E extends InferErr<U> | UnknownError
   >(
     this: U,
-    ErrorClass: AClass<E>,
+    ErrorClass: Constructor<E>,
     mapper: (err: E) => R
   ): SpreadErrors<MapErrResult<SpreadErrors<U>, R, E>>;
 
@@ -150,7 +150,7 @@ type MapErrResult<U extends Result<unknown, unknown>, R, E> = U extends Err<
     : U
   : U;
 
-interface AClass<C> {
+interface Constructor<C> {
   new (...args: any[]): C;
 }
 

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -27,7 +27,8 @@ type Ok<TValue> = Subresult & {
    * Return fulfilled promise of current Ok Result value. To use the `promise()`
    * function you need first handle all known Err result values.
    * It is possible that it return rejected promise for unknown exceptions.
-   * @returns promise of current Result value - fulfilled if the value is Ok, rejected if the was an exception throw in the mapping chain
+   * @returns promise of current Result value - fulfilled if the value is Ok,
+   *          rejected if there was an exception thrown anywhere in the mapping chain
    */
   promise<U extends Result<unknown, unknown>>(
     this: U

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,11 +1,4 @@
-import type {
-  Result as ResultType,
-  Ok,
-  Err,
-  InferOk,
-  InferErr,
-  Result,
-} from './result-helpers';
+import type { Ok, Err, InferOk, InferErr, Result } from './result-helpers';
 
 export type { ResultNamespace, OkNamespace, ErrNamespace };
 
@@ -26,7 +19,12 @@ interface ResultNamespace {
    * @param results list of Ok and/or Err Results
    * @returns Result Ok of all input Ok values, or Err Result of one of provided Err values.
    */
-  combine<T extends readonly ResultType<unknown, unknown>[]>(
+  combine<
+    T extends readonly (
+      | Result<unknown, unknown>
+      | Promise<Result<unknown, unknown>>
+    )[]
+  >(
     results: [...T]
   ): Combine<T>;
 }


### PR DESCRIPTION
Introduce concept of `UnknownError`.
In every step of Result lifecycle an unexpected error can throw. Since now it was silently proxied to `mapAnyErr` function and finally the `.promise()` would return rejected promise of such error.
Now the `UnknownError` if available in similar manner like custom error type. 

Usage with `mapErr`:
```ts
Ok.of(5)
  .map(val => {
    throw new Error('Problem!');
  })
  .mapErr(UnknownError, err => console.error(err.cause));
```

Usage with `mapAnyErr`:
```ts
Ok.of(5)
  .map(val => {
    throw new Error('Problem!');
  })
  // error is type `UnknownError`
  .mapAnyErr(err => console.error(err.cause));
```

Not handled `UnknownError` will effect with rejected promise, in the same way like before.

---
Additionally, in this PR I introduced amazing simplifications to existing result generic helpers, proposed by @mskrajnowski 
https://github.com/wiktor-obrebski/type-safe-errors/pull/16/files