### PR TITLE
Allows use Promises of results as `Result.combine` arguments

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -253,8 +253,9 @@ const rejectedPromise = errResult.unsafePromise();
 ### Result.combine([result1, result2, ...])
 
 Combines a list of provided results into a single result.
-If all provided results are `Ok`, the returned result will be an `Ok` containing
-an array of values from the provided results: `[Ok<A>, Ok<B>] -> Ok<[A, B]>`.  
+The results can be either `Result` instances or promises that resolve to `Result` instances.
+If all provided results are `Ok`, the returned result
+will be an `Ok` containing an array of values from the provided results: `[Ok<A>, Ok<B>] -> Ok<[A, B]>`.  
 
 If provided results list have at least one `Err` result,
 returned result will be `Err` of first `Err` result value found in the array.
@@ -264,7 +265,9 @@ The `Result.combine` operation is the results version of [Promise.all](https://d
 **Signature:**
 
 ```typescript
-Result.combine(results: [Result<A, Err1>, Result<B, Err2>, ...]): Result<[A, B, ...], Err1 | Err2>
+type AsyncResult<TOk, TErr> = Promise<Result<TOk, TErr>> | Result<TOk, TErr>;
+
+Result.combine(results: [AsyncResult<A, Err1>, AsyncResult<B, Err2>, ...]): Result<[A, B, ...], Err1 | Err2>
 ```
 
 **Examples:**
@@ -275,8 +278,9 @@ Successful example
 import { Ok, Result } from 'type-safe-errors';
 
 const ok1Result = Ok.of(5);
-const ok2Result = Ok.of(9);
-const okSumResult = Result.combine([ok1Result, ok2Result]).map(
+const ok2ResultFactory = async () => Ok.of(9);
+
+const okSumResult = Result.combine([ok1Result, ok2ResultFactory()]).map(
   ([val1, val2]) => val1 + val2
 )
 ```
@@ -293,7 +297,7 @@ const errResult = Err.of(new UserNotFoundError());
 
 const okSumResult = Result.combine([ok1Result, errResult, ok2Result])
   // not called, val2 is `never` type as we already know its an error
-  .map(([val1, val2, val3]) => val1 + val3))
+  .map(([val1, val2, val3]) => val1 + val3)
   // called
   .mapErr(UserNotFoundError, err => console.log('User not found!'))
 ```
@@ -308,11 +312,16 @@ const maybeErr1Result = Ok.of(5).map(
   () => Math.random() > 0.5 ? Err.of(new Error1()) : 5
 );
 
-const maybeErr2Result = Ok.of(6).map(
+const maybeErr2ResultFactory = async () => Ok.of(6).map(
   () => Math.random() > 0.5 ? Err.of(new Error2()) : 6
 );
 
-const okSumResult = Result.combine([ok1Result, maybeErr1Result , ok2Result, maybeErr2Result])
+const okSumResult = Result.combine([
+  ok1Result,
+  maybeErr1Result,
+  ok2Result,
+  maybeErr2ResultFactory()
+])
   // randomly, when all results all success, map will run
   .map(([val1, val5, val2, val6]) => val1 + val5 + val2 + val6)
   // if some of results fail, then mapAnyErr is called. `err` is Error1 or Error2 class

--- a/src/result.ts
+++ b/src/result.ts
@@ -15,8 +15,11 @@ const Result: ResultNamespace = {
   },
 
   combine(results) {
-    const wrappersPromise = Promise.all(results.map((res) => res.__value));
-    const resultPromise = wrappersPromise.then((wrappers) => {
+    const wrapperPromises = results.map((res) =>
+      Promise.resolve(res).then((v) => v.__value)
+    );
+
+    const resultPromise = Promise.all(wrapperPromises).then((wrappers) => {
       const values = [];
       for (const wrapper of wrappers) {
         if (wrapper.isError) {

--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -62,6 +62,25 @@ test('Result combine of mixed types per Result returns expected result', (done) 
   shouldEventuallyOk(mapped, ['return-type', 5], done);
 });
 
+test('Result combine of mixed types per Result and Result promises returns expected result', (done) => {
+  const mixedResult1 = Ok.of('return-type') as Err<Error1> | Ok<'return-type'>;
+  const mixedAsycnResult = Promise.resolve(
+    Ok.of('return-type2') as Err<Error2> | Ok<'return-type2'>
+  );
+
+  const mapped: Result<
+    ['return-type', number, number, 'return-type2'],
+    Error1 | Error2
+  > = Result.combine([
+    mixedResult1,
+    Ok.of(5),
+    Promise.resolve(Ok.of(5)),
+    mixedAsycnResult,
+  ]);
+
+  shouldEventuallyOk(mapped, ['return-type', 5, 5, 'return-type2'], done);
+});
+
 test('Result.combine of results with possibly undefined values preserves possibly undefined values', (done) => {
   const result = Result.combine([
     Ok.of<string | undefined>(undefined),

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,11 +1,4 @@
-import type {
-  Result as ResultType,
-  Ok,
-  Err,
-  InferOk,
-  InferErr,
-  Result,
-} from './result-helpers';
+import type { Ok, Err, InferOk, InferErr, Result } from './result-helpers';
 
 export type { ResultNamespace, OkNamespace, ErrNamespace };
 
@@ -26,7 +19,12 @@ interface ResultNamespace {
    * @param results list of Ok and/or Err Results
    * @returns Result Ok of all input Ok values, or Err Result of one of provided Err values.
    */
-  combine<T extends readonly ResultType<unknown, unknown>[]>(
+  combine<
+    T extends readonly (
+      | Result<unknown, unknown>
+      | Promise<Result<unknown, unknown>>
+    )[]
+  >(
     results: [...T]
   ): Combine<T>;
 }


### PR DESCRIPTION
This pull request the flexibility and usability of the `Result.combine` function.

Previously, `Result.combine` only accepted an array of `Result` instances. With this update, it can now also accept an array of `Promise<Result>` instances, making it more convenient to use in asynchronous contexts.

