### PR TITLE
Fix/result from generic type

### DIFF
--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -47,6 +47,19 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
+  test('returns maped result for mapper with generic result return', (done) => {
+    const err1 = new Error1();
+
+    const genericFn = <TOk extends never, TResult extends Result<TOk, Error1>>(
+      val: TResult
+    ) => {
+      const mapped: Ok<TOk> | Err<Error1> = Result.from(() => val);
+      shouldEventuallyErr(mapped, err1, done);
+    };
+
+    genericFn(Err.of(err1));
+  });
+
   test('returns maped result for mapper with promise of plain return', (done) => {
     async function getAsyncOk(value: number) {
       return `value of ${value}`;

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -85,7 +85,7 @@ interface Subresult {
    */
   mapAnyErr<U extends Result<unknown, unknown>, R>(
     this: U,
-    mapper: (value: InferErr<U>) => R
+    mapper: (value: InferErr<U> | UnknownError) => R
   ): Result<InferOk<U> | InferOk<R>, InferErr<R>>;
 
   /**

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -8,7 +8,9 @@ type Combine<Results extends readonly unknown[]> = Result<
 >;
 
 interface ResultNamespace {
-  from<R>(factory: () => R): Result<InferOk<R>, InferErr<R>>;
+  from<R>(
+    factory: () => R | Promise<R>
+  ): R extends Result<unknown, unknown> ? R : Result<InferOk<R>, InferErr<R>>;
 
   /**
    * Combine provided Results list into single Result. If all provided Results


### PR DESCRIPTION
There was an infering problem with old code, it lost types in some
rare situation. This PR fix it.

Additionally, it adds missing `UnknownType` to `mapAnyErr` signature.