### PR TITLE
Refactor/restructured result combine

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -2,6 +2,7 @@ import {
   commonResultFactory,
   resultWrapperFactory,
   wrapResultFactory,
+  isResult,
 } from './common-result';
 import { ResultNamespace, OkNamespace, ErrNamespace } from './types/result';
 
@@ -16,7 +17,9 @@ const Result: ResultNamespace = {
 
   combine(results) {
     const wrapperPromises = results.map((res) =>
-      Promise.resolve(res).then((v) => v.__value)
+      Promise.resolve(res).then((v) =>
+        isResult(v) ? v.__value : { isError: false, value: v }
+      )
     );
 
     const resultPromise = Promise.all(wrapperPromises).then((wrappers) => {

--- a/src/result.ts
+++ b/src/result.ts
@@ -15,8 +15,11 @@ const Result: ResultNamespace = {
   },
 
   combine(results) {
-    const wrappersPromise = Promise.all(results.map((res) => res.__value));
-    const resultPromise = wrappersPromise.then((wrappers) => {
+    const wrapperPromises = results.map((res) =>
+      Promise.resolve(res).then((v) => v.__value)
+    );
+
+    const resultPromise = Promise.all(wrapperPromises).then((wrappers) => {
       const values = [];
       for (const wrapper of wrappers) {
         if (wrapper.isError) {

--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -63,22 +63,37 @@ test('Result combine of mixed types per Result returns expected result', (done) 
 });
 
 test('Result combine of mixed types per Result and Result promises returns expected result', (done) => {
-  const mixedResult1 = Ok.of('return-type') as Err<Error1> | Ok<'return-type'>;
+  const mixedResult1 = Ok.of('return-type') as
+    | Err<Error1>
+    | Ok<'return-type'>
+    | undefined;
   const mixedAsycnResult = Promise.resolve(
-    Ok.of('return-type2') as Err<Error2> | Ok<'return-type2'>
+    Ok.of('return-type2') as Err<Error2> | Ok<'return-type2'> | undefined
   );
+  const errLiteralResult = undefined as undefined | Err<Error3>;
 
   const mapped: Result<
-    ['return-type', number, number, 'return-type2'],
-    Error1 | Error2
+    [
+      'return-type' | undefined,
+      number,
+      number,
+      'return-type2' | undefined,
+      undefined
+    ],
+    Error1 | Error2 | Error3
   > = Result.combine([
     mixedResult1,
     Ok.of(5),
     Promise.resolve(Ok.of(5)),
     mixedAsycnResult,
+    errLiteralResult,
   ]);
 
-  shouldEventuallyOk(mapped, ['return-type', 5, 5, 'return-type2'], done);
+  shouldEventuallyOk(
+    mapped,
+    ['return-type', 5, 5, 'return-type2', undefined],
+    done
+  );
 });
 
 test('Result.combine of results with possibly undefined values preserves possibly undefined values', (done) => {

--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -62,6 +62,25 @@ test('Result combine of mixed types per Result returns expected result', (done) 
   shouldEventuallyOk(mapped, ['return-type', 5], done);
 });
 
+test('Result combine of mixed types per Result and Result promises returns expected result', (done) => {
+  const mixedResult1 = Ok.of('return-type') as Err<Error1> | Ok<'return-type'>;
+  const mixedAsycnResult = Promise.resolve(
+    Ok.of('return-type2') as Err<Error2> | Ok<'return-type2'>
+  );
+
+  const mapped: Result<
+    ['return-type', number, number, 'return-type2'],
+    Error1 | Error2
+  > = Result.combine([
+    mixedResult1,
+    Ok.of(5),
+    Promise.resolve(Ok.of(5)),
+    mixedAsycnResult,
+  ]);
+
+  shouldEventuallyOk(mapped, ['return-type', 5, 5, 'return-type2'], done);
+});
+
 test('Result.combine of results with possibly undefined values preserves possibly undefined values', (done) => {
   const result = Result.combine([
     Ok.of<string | undefined>(undefined),

--- a/src/test/map.test.ts
+++ b/src/test/map.test.ts
@@ -150,6 +150,24 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
   });
 
+  test('returns mapped value for UnknownError err when infering type from async throwing result', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Ok.of(5).map(async (_val) => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
+  });
+
   test('rejects with throwed exception if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
@@ -994,10 +1012,28 @@ suite('mapAnyErr', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
-  test('returns mapped value for UnknownError err when infering type', (done) => {
+  test('returns mapped value for UnknownError err when mapper throws', (done) => {
     const err4 = new Error('Something happened');
 
     const result = Err.of(new Error1()).mapAnyErr(() => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
+  });
+
+  test('returns mapped value for UnknownError err when async mapper throws', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Err.of(new Error1()).mapAnyErr(async () => {
       throw err4;
     });
 
@@ -1135,10 +1171,28 @@ suite('mapErr', () => {
     }
   );
 
-  test('returns mapped value for UnknownError err when infering type', (done) => {
+  test('returns mapped value for UnknownError err when mapper throws', (done) => {
     const err4 = new Error('Something happened');
 
     const result = Err.of(new Error1()).mapErr(Error1, () => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
+  });
+
+  test('returns mapped value for UnknownError err when async mapper throws', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Err.of(new Error1()).mapErr(Error1, async () => {
       throw err4;
     });
 

--- a/src/test/map.test.ts
+++ b/src/test/map.test.ts
@@ -27,7 +27,7 @@ class Error3 extends Error {
 suite('Result map of single Ok result', () => {
   const result = Ok.of(5);
 
-  test('returns maped result for mapper with plain return', (done) => {
+  test('returns mapped result for mapper with plain return', (done) => {
     const mapped: Ok<'test-return'> = result.map((_value: number) => {
       return 'test-return' as const;
     });
@@ -35,7 +35,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyOk(mapped, 'test-return', done);
   });
 
-  test('returns maped result for mapper with ok result return', (done) => {
+  test('returns mapped result for mapper with ok result return', (done) => {
     const mapped: Ok<'test-return2'> = result.map((_value: number) => {
       return Ok.of('test-return2' as const);
     });
@@ -43,7 +43,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyOk(mapped, 'test-return2', done);
   });
 
-  test('returns maped result for mapper with err result return', (done) => {
+  test('returns mapped result for mapper with err result return', (done) => {
     const err1 = new Error1();
 
     const mapped: Err<Error1> | Err<UnknownError> = result.map(
@@ -55,7 +55,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err1 = new Error1();
 
     const mapped: Result<'test-ok', Error1> = result.map((value: number) => {
@@ -65,7 +65,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped result for mapper with promise of plain return', (done) => {
+  test('returns mapped result for mapper with promise of plain return', (done) => {
     async function getAsyncOk(value: number) {
       return `value of ${value}`;
     }
@@ -77,7 +77,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyOk(mapped, 'value of 5', done);
   });
 
-  test('returns maped result for mapper with promise of ok result return', (done) => {
+  test('returns mapped result for mapper with promise of ok result return', (done) => {
     async function getAsyncOk(value: number) {
       return Ok.of(`ok of ${value}`);
     }
@@ -89,7 +89,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyOk(mapped, 'ok of 5', done);
   });
 
-  test('returns maped result for mapper with promise of err result return', (done) => {
+  test('returns mapped result for mapper with promise of err result return', (done) => {
     const err1 = new Error1();
 
     async function getAsyncErr(_value: number) {
@@ -103,7 +103,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err1 = new Error1();
 
     async function getAsyncOk(value: number) {
@@ -120,7 +120,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped UnknownError result if mapper throws an exception', (done) => {
+  test('returns mapped UnknownError result if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
     const mapped: Ok<number> | Err<Error1> = result.map((_val: number) => {
@@ -130,6 +130,24 @@ suite('Result map of single Ok result', () => {
     });
 
     shouldEventuallyUnknownErr(mapped, err4, done);
+  });
+
+  test('returns mapped value for UnknownError err when infering type from throwing result', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Ok.of(5).map((_val) => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
   });
 
   test('rejects with throwed exception if mapper throws an exception', (done) => {
@@ -254,7 +272,7 @@ suite('Result map of mixed Ok and Err results', () => {
 
   const result = Ok.of(5) as MixedResult<number>;
 
-  test('returns maped result for mapper with plain return', (done) => {
+  test('returns mapped result for mapper with plain return', (done) => {
     const mapped: MixedResult<'test-return'> = result.map((_value: number) => {
       return 'test-return' as const;
     });
@@ -262,7 +280,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyOk(mapped, 'test-return', done);
   });
 
-  test('returns maped result for mapper with ok result return', (done) => {
+  test('returns mapped result for mapper with ok result return', (done) => {
     const mapped: MixedResult<'test-return2'> = result.map((_value: number) => {
       return Ok.of('test-return2' as const);
     });
@@ -270,7 +288,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyOk(mapped, 'test-return2', done);
   });
 
-  test('returns maped result for mapper with err result return', (done) => {
+  test('returns mapped result for mapper with err result return', (done) => {
     const err2 = new Error2();
 
     const mapped: Err<Error2> | Err<Error1> = result.map((_value: number) => {
@@ -280,7 +298,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyErr(mapped, err2, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err2 = new Error2();
 
     const mapped: Result<'test-ok', Error2 | Error1> = result.map(
@@ -292,7 +310,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped result for mapper with promise of plain return', (done) => {
+  test('returns mapped result for mapper with promise of plain return', (done) => {
     async function getAsyncOk(value: number) {
       return `value of ${value}`;
     }
@@ -304,7 +322,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyOk(mapped, 'value of 5', done);
   });
 
-  test('returns maped result for mapper with promise of ok result return', (done) => {
+  test('returns mapped result for mapper with promise of ok result return', (done) => {
     async function getAsyncOk(value: number) {
       return Ok.of(`ok of ${value}`);
     }
@@ -316,7 +334,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyOk(mapped, 'ok of 5', done);
   });
 
-  test('returns maped result for mapper with promise of err result return', (done) => {
+  test('returns mapped result for mapper with promise of err result return', (done) => {
     const err2 = new Error2();
 
     async function getAsyncOk(_value: number) {
@@ -332,7 +350,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyErr(mapped, err2, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err2 = new Error2();
 
     async function getAsyncOk(value: number) {
@@ -349,7 +367,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped UnknownError result if mapper throws an exception', (done) => {
+  test('returns mapped UnknownError result if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
     const mapped: Ok<number> | Err<Error1> = result.map((_val: number) => {
@@ -377,7 +395,7 @@ suite('Result map of mixed Ok and Err results', () => {
 suite('Result map of multiple Ok results', () => {
   const result = Ok.of(5) as Ok<number> | Ok<string>;
 
-  test('returns maped result for mapper with plain return', (done) => {
+  test('returns mapped result for mapper with plain return', (done) => {
     const mapped: Ok<'test-return'> = result.map((_value: number | string) => {
       return 'test-return' as const;
     });
@@ -385,7 +403,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyOk(mapped, 'test-return', done);
   });
 
-  test('returns maped result for mapper with ok result return', (done) => {
+  test('returns mapped result for mapper with ok result return', (done) => {
     const mapped: Ok<'test-return2'> = result.map((_value: number | string) => {
       return Ok.of('test-return2' as const);
     });
@@ -393,7 +411,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyOk(mapped, 'test-return2', done);
   });
 
-  test('returns maped result for mapper with err result return', (done) => {
+  test('returns mapped result for mapper with err result return', (done) => {
     const err1 = new Error1();
 
     const mapped: Err<Error1> = result.map((_value: number | string) => {
@@ -403,7 +421,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err1 = new Error1();
 
     const mapped: Result<'test-ok', Error1> = result.map(
@@ -415,7 +433,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped result for mapper with promise of plain return', (done) => {
+  test('returns mapped result for mapper with promise of plain return', (done) => {
     async function getAsyncOk(value: number | string) {
       return `value of ${value}`;
     }
@@ -427,7 +445,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyOk(mapped, 'value of 5', done);
   });
 
-  test('returns maped result for mapper with promise of ok result return', (done) => {
+  test('returns mapped result for mapper with promise of ok result return', (done) => {
     async function getAsyncOk(value: number | string) {
       return Ok.of(`ok of ${value}`);
     }
@@ -439,7 +457,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyOk(mapped, 'ok of 5', done);
   });
 
-  test('returns maped result for mapper with promise of err result return', (done) => {
+  test('returns mapped result for mapper with promise of err result return', (done) => {
     const err1 = new Error1();
 
     async function getAsyncOk(_value: number | string) {
@@ -453,7 +471,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err1 = new Error1();
 
     async function getAsyncOk(value: number | string) {
@@ -470,7 +488,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped UnknownError result if mapper throws an exception', (done) => {
+  test('returns mapped UnknownError result if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
     const mapped: Ok<number> | Err<Error1> = result.map(
@@ -504,7 +522,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
 
   const result = Ok.of(5) as MixedResult<number>;
 
-  test('returns maped result for mapper with plain return', (done) => {
+  test('returns mapped result for mapper with plain return', (done) => {
     const mapped: MixedResult<'test-return'> = result.map((_value: number) => {
       return 'test-return' as const;
     });
@@ -512,7 +530,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'test-return', done);
   });
 
-  test('returns maped result for mapper with ok result return', (done) => {
+  test('returns mapped result for mapper with ok result return', (done) => {
     const mapped: MixedResult<'test-return2'> = result.map((_value: number) => {
       return Ok.of('test-return2' as const);
     });
@@ -520,7 +538,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'test-return2', done);
   });
 
-  test('returns maped result for mapper with err result return', (done) => {
+  test('returns mapped result for mapper with err result return', (done) => {
     const err3 = new Error3();
 
     const mapped: Err<Error3> | Err<Error1> | Err<Error2> = result.map(
@@ -532,7 +550,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyErr(mapped, err3, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err3 = new Error3();
 
     const mapped: Result<'test-ok', Error3 | Error1 | Error2> = result.map(
@@ -544,7 +562,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped result for mapper with promise of plain return', (done) => {
+  test('returns mapped result for mapper with promise of plain return', (done) => {
     async function getAsyncOk(value: number) {
       return `value of ${value}`;
     }
@@ -556,7 +574,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'value of 5', done);
   });
 
-  test('returns maped result for mapper with promise of ok result return', (done) => {
+  test('returns mapped result for mapper with promise of ok result return', (done) => {
     async function getAsyncOk(value: number) {
       return Ok.of(`ok of ${value}`);
     }
@@ -568,7 +586,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'ok of 5', done);
   });
 
-  test('returns maped result for mapper with promise of err result return', (done) => {
+  test('returns mapped result for mapper with promise of err result return', (done) => {
     const err3 = new Error3();
 
     async function getAsyncOk(_value: number) {
@@ -584,7 +602,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyErr(mapped, err3, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err3 = new Error3();
 
     async function getAsyncOk(value: number) {
@@ -601,7 +619,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped UnknownError result if mapper throws an exception', (done) => {
+  test('returns mapped UnknownError result if mapper throws an exception', (done) => {
     const err4 = new Error3();
 
     const mapped: Ok<number> | Err<Error1> | Err<Error2> = result.map(
@@ -749,7 +767,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
 
   const result = Ok.of(5) as Ok<string> | MixedResult<number>;
 
-  test('returns maped result for mapper with plain return', (done) => {
+  test('returns mapped result for mapper with plain return', (done) => {
     const mapped: MixedResult<'test-return'> = result.map(
       (_value: number | string) => {
         return 'test-return' as const;
@@ -759,7 +777,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'test-return', done);
   });
 
-  test('returns maped result for mapper with ok result return', (done) => {
+  test('returns mapped result for mapper with ok result return', (done) => {
     const mapped: MixedResult<'test-return2'> = result.map(
       (_value: number | string) => {
         return Ok.of('test-return2' as const);
@@ -769,7 +787,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'test-return2', done);
   });
 
-  test('returns maped result for mapper with err result return', (done) => {
+  test('returns mapped result for mapper with err result return', (done) => {
     const err3 = new Error3();
 
     const mapped: Err<Error3> | Err<Error1> | Err<Error2> = result.map(
@@ -781,7 +799,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyErr(mapped, err3, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err3 = new Error3();
 
     const mapped: Result<'test-ok', Error3 | Error1 | Error2> = result.map(
@@ -793,7 +811,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped result for mapper with promise of plain return', (done) => {
+  test('returns mapped result for mapper with promise of plain return', (done) => {
     async function getAsyncOk(value: number | string) {
       return `value of ${value}`;
     }
@@ -807,7 +825,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'value of 5', done);
   });
 
-  test('returns maped result for mapper with promise of ok result return', (done) => {
+  test('returns mapped result for mapper with promise of ok result return', (done) => {
     async function getAsyncOk(value: number | string) {
       return Ok.of(`ok of ${value}`);
     }
@@ -821,7 +839,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'ok of 5', done);
   });
 
-  test('returns maped result for mapper with promise of err result return', (done) => {
+  test('returns mapped result for mapper with promise of err result return', (done) => {
     const err3 = new Error3();
 
     async function getAsyncOk(_value: number | string) {
@@ -837,7 +855,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyErr(mapped, err3, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err3 = new Error3();
 
     async function getAsyncOk(value: number | string) {
@@ -869,7 +887,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyReject(mapped, err4, done);
   });
 
-  test('returns maped UnknownError result if mapper throws an exception', (done) => {
+  test('returns mapped UnknownError result if mapper throws an exception', (done) => {
     const err4 = new Error3();
 
     const mapped: Ok<number> | Err<Error1> | Err<Error2> = result.map(
@@ -976,7 +994,25 @@ suite('mapAnyErr', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
-  test('returns maped UnknownError result if mapper throws an exception', (done) => {
+  test('returns mapped value for UnknownError err when infering type', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Err.of(new Error1()).mapAnyErr(() => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
+  });
+
+  test('returns mapped UnknownError result if mapper throws an exception', (done) => {
     const err1 = new Error1();
     const err4 = new Error2();
 
@@ -1099,7 +1135,25 @@ suite('mapErr', () => {
     }
   );
 
-  test('returns maped value for UnknownError err', (done) => {
+  test('returns mapped value for UnknownError err when infering type', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Err.of(new Error1()).mapErr(Error1, () => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.mapErr(
+      UnknownError,
+      (err: UnknownError) => {
+        expect(err.cause).to.equal(err4);
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
+  });
+
+  test('returns mapped value for UnknownError err', (done) => {
     const err4 = new Error('Something happened');
 
     const result = Result.from(() => {
@@ -1115,7 +1169,7 @@ suite('mapErr', () => {
     shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
   });
 
-  test('returns maped UnknownError result if mapper throws an exception', (done) => {
+  test('returns mapped UnknownError result if mapper throws an exception', (done) => {
     const err1 = new Error1();
     const err4 = new Error2();
 

--- a/src/test/map.test.ts
+++ b/src/test/map.test.ts
@@ -170,7 +170,7 @@ suite('Result map of single Ok result', () => {
     shouldEventuallyOk(mapped, 'mapped-unknown-err-result', done);
   });
 
-  test('rejects with throwed exception if mapper throws an exception', (done) => {
+  test('rejects with thrown exception if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
     const mapped: Ok<number> | Err<Error1> = result.map((_val: number) => {
@@ -401,7 +401,7 @@ suite('Result map of mixed Ok and Err results', () => {
     shouldEventuallyUnknownErr(mapped, err4, done);
   });
 
-  test('rejects with throwed exception if mapper throws an exception', (done) => {
+  test('rejects with thrown exception if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
     const mapped: Ok<number> | Err<Error1> = result.map((_val: number) => {
@@ -528,7 +528,7 @@ suite('Result map of multiple Ok results', () => {
     shouldEventuallyUnknownErr(mapped, err4, done);
   });
 
-  test('rejects with throwed exception if mapper throws an exception', (done) => {
+  test('rejects with thrown exception if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
     const mapped: Ok<number> | Err<Error1> = result.map(
@@ -657,7 +657,7 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     shouldEventuallyUnknownErr(mapped, err4, done);
   });
 
-  test('rejects with throwed exception if mapper throws an exception', (done) => {
+  test('rejects with thrown exception if mapper throws an exception', (done) => {
     const err4 = new Error3();
 
     const mapped: Ok<number> | Err<Error1> | Err<Error2> = result.map(
@@ -895,12 +895,12 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('rejects with throwed exception if mapper throws an exception', (done) => {
+  test('rejects with thrown exception if mapper throws an exception', (done) => {
     const err4 = new Error2();
 
     const result = Ok.of(5) as Err<Error1> | Ok<number>;
 
-    // the throwed error type is included in result types always, as UnknownError
+    // the thrown error type is included in result types always, as UnknownError
     const mapped: Ok<number> | Err<Error1> = result.map((_val: number) => {
       if (true) {
         throw err4;
@@ -924,7 +924,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     shouldEventuallyUnknownErr(mapped, err4, done);
   });
 
-  test('rejects with throwed exception if mapper throws an exception', (done) => {
+  test('rejects with thrown exception if mapper throws an exception', (done) => {
     const err4 = new Error3();
 
     const mapped: Ok<number> | Err<Error1> | Err<Error2> = result.map(
@@ -1070,13 +1070,13 @@ suite('mapAnyErr', () => {
     shouldEventuallyUnknownErr(mapped, err4, done);
   });
 
-  test('rejects with throwed exception if mapper throws an exception', (done) => {
+  test('rejects with thrown exception if mapper throws an exception', (done) => {
     const err1 = new Error1();
     const err4 = new Error2();
 
     const result = Err.of(err1) as Err<Error1> | Ok<number>;
 
-    // the throwed error type is included in result types awalys, as UnknownError
+    // the thrown error type is included in result types awalys, as UnknownError
     const mapped: Ok<number> = result.mapAnyErr(
       (_err: Error1 | UnknownError) => {
         if (true) {
@@ -1243,13 +1243,13 @@ suite('mapErr', () => {
     shouldEventuallyUnknownErr(mapped, err4, done);
   });
 
-  test('rejects with throwed exception if mapper throws an exception', (done) => {
+  test('rejects with thrown exception if mapper throws an exception', (done) => {
     const err1 = new Error1();
     const err4 = new Error2();
 
     const result = Err.of(err1) as Err<Error1> | Ok<number>;
 
-    // the throwed error type is included in result types awalys, as UnknownError
+    // the thrown error type is included in result types awalys, as UnknownError
     const mapped: Ok<number> = result.mapErr(Error1, (_err: Error1) => {
       if (true) {
         throw err4;

--- a/src/test/map.test.ts
+++ b/src/test/map.test.ts
@@ -46,7 +46,7 @@ suite('Result map of single Ok result', () => {
   test('returns mapped result for mapper with err result return', (done) => {
     const err1 = new Error1();
 
-    const mapped: Err<Error1> | Err<UnknownError> = result.map(
+    const mapped: Err<Error1> | Err<UnknownError> | Ok<never> = result.map(
       (_value: number) => {
         return Err.of(err1);
       }
@@ -95,10 +95,12 @@ suite('Result map of single Ok result', () => {
     async function getAsyncErr(_value: number) {
       return Err.of(err1);
     }
-    const mapped: Err<Error1> = result.map(async (value: number) => {
-      const res = await getAsyncErr(value);
-      return res;
-    });
+    const mapped: Err<Error1> | Ok<never> = result.map(
+      async (value: number) => {
+        const res = await getAsyncErr(value);
+        return res;
+      }
+    );
 
     shouldEventuallyErr(mapped, err1, done);
   });
@@ -309,9 +311,11 @@ suite('Result map of mixed Ok and Err results', () => {
   test('returns mapped result for mapper with err result return', (done) => {
     const err2 = new Error2();
 
-    const mapped: Err<Error2> | Err<Error1> = result.map((_value: number) => {
-      return Err.of(err2);
-    });
+    const mapped: Err<Error2> | Err<Error1> | Ok<never> = result.map(
+      (_value: number) => {
+        return Err.of(err2);
+      }
+    );
 
     shouldEventuallyErr(mapped, err2, done);
   });
@@ -358,7 +362,7 @@ suite('Result map of mixed Ok and Err results', () => {
     async function getAsyncOk(_value: number) {
       return Err.of(err2);
     }
-    const mapped: Err<Error2> | Err<Error1> = result.map(
+    const mapped: Err<Error2> | Err<Error1> | Ok<never> = result.map(
       async (value: number) => {
         const res = await getAsyncOk(value);
         return res;
@@ -432,9 +436,11 @@ suite('Result map of multiple Ok results', () => {
   test('returns mapped result for mapper with err result return', (done) => {
     const err1 = new Error1();
 
-    const mapped: Err<Error1> = result.map((_value: number | string) => {
-      return Err.of(err1);
-    });
+    const mapped: Err<Error1> | Ok<never> = result.map(
+      (_value: number | string) => {
+        return Err.of(err1);
+      }
+    );
 
     shouldEventuallyErr(mapped, err1, done);
   });
@@ -481,10 +487,12 @@ suite('Result map of multiple Ok results', () => {
     async function getAsyncOk(_value: number | string) {
       return Err.of(err1);
     }
-    const mapped: Err<Error1> = result.map(async (value: number | string) => {
-      const res = await getAsyncOk(value);
-      return res;
-    });
+    const mapped: Err<Error1> | Ok<never> = result.map(
+      async (value: number | string) => {
+        const res = await getAsyncOk(value);
+        return res;
+      }
+    );
 
     shouldEventuallyErr(mapped, err1, done);
   });
@@ -559,11 +567,10 @@ suite('Result map of mixed Ok and 2 Err results', () => {
   test('returns mapped result for mapper with err result return', (done) => {
     const err3 = new Error3();
 
-    const mapped: Err<Error3> | Err<Error1> | Err<Error2> = result.map(
-      (_value: number) => {
+    const mapped: Err<Error3> | Err<Error1> | Err<Error2> | Ok<never> =
+      result.map((_value: number) => {
         return Err.of(err3);
-      }
-    );
+      });
 
     shouldEventuallyErr(mapped, err3, done);
   });
@@ -610,12 +617,11 @@ suite('Result map of mixed Ok and 2 Err results', () => {
     async function getAsyncOk(_value: number) {
       return Err.of(err3);
     }
-    const mapped: Err<Error3> | Err<Error1> | Err<Error2> = result.map(
-      async (value: number) => {
+    const mapped: Err<Error3> | Err<Error1> | Err<Error2> | Ok<never> =
+      result.map(async (value: number) => {
         const res = await getAsyncOk(value);
         return res;
-      }
-    );
+      });
 
     shouldEventuallyErr(mapped, err3, done);
   });
@@ -808,11 +814,10 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
   test('returns mapped result for mapper with err result return', (done) => {
     const err3 = new Error3();
 
-    const mapped: Err<Error3> | Err<Error1> | Err<Error2> = result.map(
-      (_value: number | string) => {
+    const mapped: Err<Error3> | Err<Error1> | Err<Error2> | Ok<never> =
+      result.map((_value: number | string) => {
         return Err.of(err3);
-      }
-    );
+      });
 
     shouldEventuallyErr(mapped, err3, done);
   });
@@ -863,7 +868,7 @@ suite('Result map of mixed 2 Ok and 2 Err results', () => {
     async function getAsyncOk(_value: number | string) {
       return Err.of(err3);
     }
-    const mapped: Err<Error3> | Err<Error1> | Err<Error2> = result.map(
+    const mapped: Err<Error3> | Err<Error1> | Err<Error2> | Ok<never> = result.map(
       async (value: number | string) => {
         const res = await getAsyncOk(value);
         return res;
@@ -1158,7 +1163,7 @@ suite('mapErr', () => {
       const err1 = new Error1();
       const err2 = new Error2();
 
-      const result = Err.of(err1) as Err<Error1 | Error3> | Ok<number>;
+      const result = Err.of(err1) as Err<Error1> | Err<Error3> | Ok<number>;
 
       const mapped: Ok<number> | Ok<void> | Err<Error2> = result
         .mapErr(Error1, (_err: Error1) => {

--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -3,6 +3,7 @@ import {
   shouldEventuallyOk,
   shouldEventuallyErr,
   shouldEventuallyReject,
+  shouldEventuallyUnknownErr,
 } from './helper';
 
 class Error1 {
@@ -10,7 +11,7 @@ class Error1 {
 }
 
 suite('Result.from of an result factory', () => {
-  test('returns maped result for mapper with plain return', (done) => {
+  test('returns mapped result for mapper with plain return', (done) => {
     const mapped: Ok<'test-return'> = Result.from(() => {
       return 'test-return' as const;
     });
@@ -18,7 +19,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyOk(mapped, 'test-return', done);
   });
 
-  test('returns maped result for mapper with ok result return', (done) => {
+  test('returns mapped result for mapper with ok result return', (done) => {
     const mapped: Ok<'test-return2'> = Result.from(() => {
       return Ok.of('test-return2' as const);
     });
@@ -26,7 +27,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyOk(mapped, 'test-return2', done);
   });
 
-  test('returns maped result for mapper with err result return', (done) => {
+  test('returns mapped result for mapper with err result return', (done) => {
     const err1 = new Error1();
 
     const mapped: Err<Error1> = Result.from(() => {
@@ -36,7 +37,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err1 = new Error1();
     const value = 5;
 
@@ -47,7 +48,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns maped result for mapper with promise of plain return', (done) => {
+  test('returns mapped result for mapper with promise of plain return', (done) => {
     async function getAsyncOk(value: number) {
       return `value of ${value}`;
     }
@@ -59,7 +60,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyOk(mapped, 'value of 5', done);
   });
 
-  test('returns maped result for mapper with promise of ok result return', (done) => {
+  test('returns mapped result for mapper with promise of ok result return', (done) => {
     async function getAsyncOk(value: number) {
       return Ok.of(`ok of ${value}`);
     }
@@ -71,7 +72,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyOk(mapped, 'ok of 5', done);
   });
 
-  test('returns maped result for mapper with generic result return', (done) => {
+  test('returns mapped result for mapper with generic result return', (done) => {
     const err1 = new Error1();
 
     const genericFn = <TOk extends never, TResult extends Result<TOk, Error1>>(
@@ -84,7 +85,7 @@ suite('Result.from of an result factory', () => {
     genericFn(Err.of(err1));
   });
 
-  test('returns maped result for mapper with promise of err result return', (done) => {
+  test('returns mapped result for mapper with promise of err result return', (done) => {
     const err1 = new Error1();
 
     async function getAsyncErr(_value: number) {
@@ -98,7 +99,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyErr(mapped, err1, done);
   });
 
-  test('returns maped result for mapper with mixed result return', (done) => {
+  test('returns mapped result for mapper with mixed result return', (done) => {
     const err1 = new Error1();
 
     async function getAsyncResult(value: number) {
@@ -127,5 +128,21 @@ suite('Result.from of an result factory', () => {
     });
 
     shouldEventuallyReject(mapped, 'Something goes wrong', done);
+  });
+
+  test('returns maped value if from throws an exception', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Result.from(() => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.map(
+      () => {
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyUnknownErr(mapped, err4, done);
   });
 });

--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -130,10 +130,26 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyReject(mapped, 'Something goes wrong', done);
   });
 
-  test('returns maped value if from throws an exception', (done) => {
+  test('returns maped value for throwing sync mapper', (done) => {
     const err4 = new Error('Something happened');
 
     const result = Result.from(() => {
+      throw err4;
+    });
+
+    const mapped: Ok<'mapped-unknown-err-result'> = result.map(
+      () => {
+        return 'mapped-unknown-err-result' as const;
+      }
+    );
+
+    shouldEventuallyUnknownErr(mapped, err4, done);
+  });
+
+  test('returns maped value for throwing async mapper', (done) => {
+    const err4 = new Error('Something happened');
+
+    const result = Result.from(async () => {
       throw err4;
     });
 

--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -114,7 +114,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyOk(mapped, 'test-ok', done);
   });
 
-  test('returns rejected result for throwing async mapper', (done) => {
+  test('returns rejected result when throwing async mapper', (done) => {
     const mapped: Result<never, never> = Result.from(async () => {
       throw new Error('Something goes wrong');
     });
@@ -122,7 +122,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyReject(mapped, 'Something goes wrong', done);
   });
 
-  test('returns rejected result for throwing sync mapper', (done) => {
+  test('returns rejected result when throwing sync mapper', (done) => {
     const mapped: Result<never, never> = Result.from(() => {
       throw new Error('Something goes wrong');
     });
@@ -130,7 +130,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyReject(mapped, 'Something goes wrong', done);
   });
 
-  test('returns maped value for throwing sync mapper', (done) => {
+  test('returns mapped value when throwing sync mapper', (done) => {
     const err4 = new Error('Something happened');
 
     const result = Result.from(() => {
@@ -146,7 +146,7 @@ suite('Result.from of an result factory', () => {
     shouldEventuallyUnknownErr(mapped, err4, done);
   });
 
-  test('returns maped value for throwing async mapper', (done) => {
+  test('returns mapped value when throwing async mapper', (done) => {
     const err4 = new Error('Something happened');
 
     const result = Result.from(async () => {

--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -30,7 +30,7 @@ suite('Result.from of an result factory', () => {
   test('returns mapped result for mapper with err result return', (done) => {
     const err1 = new Error1();
 
-    const mapped: Err<Error1> = Result.from(() => {
+    const mapped: Err<Error1> | Ok<never> = Result.from(() => {
       return Err.of(err1);
     });
 
@@ -91,7 +91,7 @@ suite('Result.from of an result factory', () => {
     async function getAsyncErr(_value: number) {
       return Err.of(err1);
     }
-    const mapped: Err<Error1> = Result.from(async () => {
+    const mapped: Err<Error1> | Ok<never> = Result.from(async () => {
       const res = await getAsyncErr(5);
       return res;
     });

--- a/src/types/common-result.ts
+++ b/src/types/common-result.ts
@@ -9,7 +9,6 @@ import type {
   InferErr,
   Err,
   UnknownError,
-  Normalize,
 } from './result-helpers';
 
 export type { CommonResult, ResultWrapper };
@@ -21,9 +20,13 @@ interface CommonResult<TErrorOrValue> {
   map<U extends Result<unknown, unknown>, R>(
     this: U,
     mapper: (value: InferOk<U>) => R | Promise<R>
-  ): Normalize<MapOkResult<U, R>>;
+  ): MapOkResult<U, R>;
 
-  mapErr<U extends Result<unknown, unknown>, R extends {}, E extends InferErr<U> | UnknownError>(
+  mapErr<
+    U extends Result<unknown, unknown>,
+    R extends {},
+    E extends InferErr<U> | UnknownError
+  >(
     this: U,
     ErrorClass: Constructor<E>,
     mapper: (err: E) => R | Promise<R>

--- a/src/types/common-result.ts
+++ b/src/types/common-result.ts
@@ -1,16 +1,15 @@
 import type {
   Result,
   Constructor,
-  OkMapper,
   MapOkResult,
   InferOk,
   ErrMapper,
   MapErrResult,
   MapAnyErrResult,
   InferErr,
-  SpreadErrors,
   Err,
   UnknownError,
+  Normalize,
 } from './result-helpers';
 
 export type { CommonResult, ResultWrapper };
@@ -21,23 +20,19 @@ interface CommonResult<TErrorOrValue> {
 
   map<U extends Result<unknown, unknown>, R>(
     this: U,
-    mapper: OkMapper<U, R>
-  ): SpreadErrors<MapOkResult<SpreadErrors<U>, R>>;
+    mapper: (value: InferOk<U>) => R | Promise<R>
+  ): Normalize<MapOkResult<U, R>>;
 
-  mapErr<
-    U extends Result<unknown, unknown>,
-    R,
-    E extends InferErr<U> | UnknownError
-  >(
+  mapErr<U extends Result<unknown, unknown>, R extends {}, E extends InferErr<U> | UnknownError>(
     this: U,
     ErrorClass: Constructor<E>,
-    mapper: (err: E) => R
-  ): SpreadErrors<MapErrResult<SpreadErrors<U>, R, E>>;
+    mapper: (err: E) => R | Promise<R>
+  ): MapErrResult<U, R, E>;
 
   mapAnyErr<U extends Result<unknown, unknown>, R>(
     this: U,
     mapper: ErrMapper<U | Err<UnknownError>, R>
-  ): SpreadErrors<MapAnyErrResult<SpreadErrors<U>, R>>;
+  ): MapAnyErrResult<U, R>;
 
   unsafePromise<U extends Result<unknown, unknown>>(
     this: U

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -124,7 +124,9 @@ type MapOkResult<U extends Result<unknown, unknown>, R> = U extends Ok<unknown>
   ? ResultOrOk<SimpleAwaited<R>>
   : U;
 
-type ResultOrOk<R> = R extends Result<unknown, unknown>
+type ResultOrOk<R> = [R] extends [never]
+  ? Ok<never>
+  : R extends Result<unknown, unknown>
   ? R
   : Ok<SimpleAwaited<R>>;
 

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -14,7 +14,6 @@ export type {
   InferErr,
   UnknownError,
   SimpleAwaited,
-  Normalize,
 };
 
 interface UnknownError extends Error {
@@ -57,7 +56,7 @@ interface Subresult {
   map<U extends Result<unknown, unknown>, R>(
     this: U,
     mapper: (value: InferOk<U>) => R | Promise<R>
-  ): Normalize<MapOkResult<U, R>>;
+  ): MapOkResult<U, R>;
 
   /**
    * Map current Result if it's a Err of a specific class.
@@ -67,7 +66,11 @@ interface Subresult {
    * @param mapper the function used to map the current Err result, can be async
    * @returns new Result, mapped if current Result is Err of specific class, left unchanged otherwise
    */
-  mapErr<U extends Result<unknown, unknown>, R, E extends InferErr<U> | UnknownError>(
+  mapErr<
+    U extends Result<unknown, unknown>,
+    R,
+    E extends InferErr<U> | UnknownError
+  >(
     this: U,
     ErrorClass: Constructor<E>,
     mapper: (err: E) => R | Promise<R>
@@ -106,31 +109,25 @@ type ErrMapper<U extends Result<unknown, unknown>, R> = (
   value: InferErr<U> | UnknownError
 ) => R | Promise<R>;
 
-type MapFromResult<R> = ResultOrOk<SimpleAwaited<R>>;
+type MapFromResult<R> = ResultOrOk<SimpleAwaited<R>> | Ok<never>;
 
-type MapOkResult<U, R> = U extends Ok<unknown>
-  ? ResultOrOk<R>
-  : U;
-
-type ResultOrOk<R> = R extends Result<unknown, unknown> ? R : Ok<R>;
+type MapOkResult<U, R> = U extends Ok<unknown> ? ResultOrOk<R> | Ok<never> : U;
 
 type MapAnyErrResult<
   U extends Result<unknown, unknown>,
   R
 > = U extends Err<unknown>
-  ? ResultOrOk<Exclude<SimpleAwaited<R>, Err<UnknownError>>>
+  ? ResultOrOk<Exclude<SimpleAwaited<R>, Err<UnknownError>>> | Ok<never>
   : U;
 
 type MapErrResult<U, R, E> = U extends Err<infer EUnion>
   ? E extends EUnion
-    ? ResultOrOk<R>
+    ? ResultOrOk<R> | Ok<never>
     : U
   : U;
+
+type ResultOrOk<R> = R extends Result<unknown, unknown> ? R : Ok<R>;
 
 interface Constructor<C> {
   new (...args: any[]): C;
 }
-
-type Normalize<T> = T;
-
-// type Normalize2 = Normalize<never>;

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -114,40 +114,28 @@ type ErrMapper<U extends Result<unknown, unknown>, R> = (
   value: InferErr<U> | UnknownError
 ) => R;
 
-type MapFromResult<R> = R extends Result<unknown, unknown>
-  ? SpreadErrors<R>
-  : R extends Promise<infer S>
-  ? ResultOrOk<S>
-  : ResultOrOk<R>;
+type MapFromResult<R> = SpreadErrors<ResultOrOk<Awaited<R>>>;
 
 type MapOkResult<U extends Result<unknown, unknown>, R> = U extends Ok<unknown>
-  ? R extends Promise<infer S>
-    ? ResultOrOk<S>
-    : ResultOrOk<R>
+  ? ResultOrOk<Awaited<R>>
   : U;
 
-type PromiseValue<TPromise> = TPromise extends Promise<infer T> ? T : TPromise;
-
-type ResultOrOk<R> = R extends Result<unknown, unknown>
+type ResultOrOk<R> = [R] extends [never]
+  ? Ok<never>
+  : R extends Result<unknown, unknown>
   ? R
-  : Ok<PromiseValue<R>>;
+  : Ok<Awaited<R>>;
 
 type MapAnyErrResult<
   U extends Result<unknown, unknown>,
   R
-> = U extends Err<unknown>
-  ? R extends Promise<infer S>
-    ? ResultOrOk<Exclude<S, Err<UnknownError>>>
-    : ResultOrOk<Exclude<R, Err<UnknownError>>>
-  : U;
+> = U extends Err<unknown> ? ResultOrOk<Exclude<R, Err<UnknownError>>> : U;
 
 type MapErrResult<U extends Result<unknown, unknown>, R, E> = U extends Err<
   infer EUnion
 >
   ? E extends EUnion
-    ? R extends Promise<infer S>
-      ? ResultOrOk<S>
-      : ResultOrOk<R>
+    ? ResultOrOk<Awaited<R>>
     : U
   : U;
 

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -13,7 +13,6 @@ export type {
   MapAnyErrResult,
   InferErr,
   UnknownError,
-  SimpleAwaited,
 };
 
 interface UnknownError extends Error {
@@ -98,9 +97,6 @@ interface Subresult {
   ): Promise<InferOk<U> | never>;
 }
 
-// build-in awaited is much more complex, often makes the types too deep
-type SimpleAwaited<TPromise> = TPromise extends Promise<infer T> ? T : TPromise;
-
 type InferOk<U> = U extends Ok<infer T> ? T : never;
 
 type InferErr<U> = U extends Err<infer T> ? T : never;
@@ -109,7 +105,7 @@ type ErrMapper<U extends Result<unknown, unknown>, R> = (
   value: InferErr<U> | UnknownError
 ) => R | Promise<R>;
 
-type MapFromResult<R> = ResultOrOk<SimpleAwaited<R>> | Ok<never>;
+type MapFromResult<R> = ResultOrOk<R> | Ok<never>;
 
 type MapOkResult<U, R> = U extends Ok<unknown> ? ResultOrOk<R> | Ok<never> : U;
 
@@ -117,7 +113,7 @@ type MapAnyErrResult<
   U extends Result<unknown, unknown>,
   R
 > = U extends Err<unknown>
-  ? ResultOrOk<Exclude<SimpleAwaited<R>, Err<UnknownError>>> | Ok<never>
+  ? ResultOrOk<Exclude<R, Err<UnknownError>>> | Ok<never>
   : U;
 
 type MapErrResult<U, R, E> = U extends Err<infer EUnion>

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,15 +1,11 @@
 import type {
-  Result as ResultType,
   Ok,
   Err,
-  SpreadErrors,
   MapFromResult,
   SimpleAwaited,
 } from './result-helpers';
 
 export type { ResultNamespace, OkNamespace, ErrNamespace };
-
-type AnyResult = ResultType<unknown, unknown>;
 
 interface ResultNamespace {
   from<R>(factory: () => R): MapFromResult<R>;
@@ -25,7 +21,7 @@ interface ResultNamespace {
    */
   combine<T extends readonly unknown[]>(
     results: [...T]
-  ): SpreadErrors<ResultType<ExtractOkTypes<T>, ExtractErrTypes<T>[number]>>;
+  ): Ok<ExtractOkTypes<T>> | ExtractErrTypes<T>[number];
 }
 
 interface OkNamespace {
@@ -64,6 +60,4 @@ type ExtractOkFromUnion<T> = T extends Err<unknown>
   : T;
 
 // need to be separated generic type to run it for every element of union T separately
-type ExtractErrFromUnion<T> = T extends Err<infer E>
-  ? E
-  : never;
+type ExtractErrFromUnion<T> = T extends Err<unknown> ? T : never;

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -4,6 +4,7 @@ import type {
   Err,
   SpreadErrors,
   MapFromResult,
+  SimpleAwaited,
 } from './result-helpers';
 
 export type { ResultNamespace, OkNamespace, ErrNamespace };
@@ -47,12 +48,12 @@ interface ErrNamespace {
 
 // Given a list of Results, this infer all the different `Ok` types from that list
 type ExtractOkTypes<T extends readonly unknown[]> = {
-  [Key in keyof T]: ExtractOkFromUnion<Awaited<T[Key]>>;
+  [Key in keyof T]: ExtractOkFromUnion<SimpleAwaited<T[Key]>>;
 };
 
 // Given a list of Results, this infer all the different `Err` types from that list
 type ExtractErrTypes<T extends readonly unknown[]> = {
-  [Key in keyof T]: ExtractErrFromUnion<Awaited<T[Key]>>;
+  [Key in keyof T]: ExtractErrFromUnion<SimpleAwaited<T[Key]>>;
 };
 
 // need to be separated generic type to run it for every element of union T separately

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,14 +1,9 @@
-import type {
-  Ok,
-  Err,
-  MapFromResult,
-  SimpleAwaited,
-} from './result-helpers';
+import type { Ok, Err, MapFromResult } from './result-helpers';
 
 export type { ResultNamespace, OkNamespace, ErrNamespace };
 
 interface ResultNamespace {
-  from<R>(factory: () => R): MapFromResult<R>;
+  from<R>(factory: () => Promise<R> | R): MapFromResult<R>;
 
   /**
    * Combine provided Results list into single Result. If all provided Results
@@ -44,12 +39,12 @@ interface ErrNamespace {
 
 // Given a list of Results, this infer all the different `Ok` types from that list
 type ExtractOkTypes<T extends readonly unknown[]> = {
-  [Key in keyof T]: ExtractOkFromUnion<SimpleAwaited<T[Key]>>;
+  [Key in keyof T]: ExtractOkFromUnion<Awaited<T[Key]>>;
 };
 
 // Given a list of Results, this infer all the different `Err` types from that list
 type ExtractErrTypes<T extends readonly unknown[]> = {
-  [Key in keyof T]: ExtractErrFromUnion<SimpleAwaited<T[Key]>>;
+  [Key in keyof T]: ExtractErrFromUnion<Awaited<T[Key]>>;
 };
 
 // need to be separated generic type to run it for every element of union T separately


### PR DESCRIPTION
Revert types back to version before 0.3.0 which breaks few important things.
Over that, re-implement `Result.combine` for async results logic again.