### PR TITLE
Improve recommended type branding strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In this example, we demonstrate how to use the `type-safe-errors` library to han
 import { Ok, Err } from 'type-safe-errors';
 
 class InvalidCredentialsError extends Error {
-  name = 'InvalidCredentialsError' as const;
+  private __brand!: never;
 }
 
 // Function to authorize an user based on their username and password
@@ -80,11 +80,11 @@ There are a few ways to handle this, but the simplest is to use the dedicated he
 import { Ok, Err, Result } from 'type-safe-errors';
 
 class InvalidCredentialsError extends Error {
-  name = 'InvalidCredentialsError' as const;
+  private __brand!: never;
 }
 
 class UserNotFoundError extends Error {
-  name = 'UserNotFoundError' as const;
+  private __brand!: never;
 }
 
 async function authorizeUser(username: string, password: string) {
@@ -191,12 +191,12 @@ An alternative is to abstain from extending by JavaScript [Error](https://develo
 ```ts
 // original
 class InvalidCredentialsError extends Error {
-  name = 'InvalidCredentials' as const;
+  private __brand!: never;
 }
 
 // without Error parent
 class InvalidCredentialsError {
-  name = 'InvalidCredentials' as const;
+  private __brand!: never;
 }
 ```
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -198,11 +198,16 @@ Err.of<TError>(value: TError): Err<TError>
 import { Err } from 'type-safe-errors';
 
 class UserNotFoundError extends Error {
-  name = 'UserNotFoundError' as const;
+  private __brand!: never;
 }
 
 const errResult = Err.of(new UserNotFoundError());
 ```
+
+Error objects must be branded, by e.g.:
+`private __brand!: never;`
+
+Type branding is a technique used to create nominal (distinct) types in TypeScript. By adding a unique dummy private field to a class, you can differentiate it from other types that share the same structure. Without it, many error classes would be indistinguishable from TypeScript's perspective, which could lead to runtime issues.
 
 ---
 
@@ -395,7 +400,7 @@ import { Result, Err } from 'type-safe-errors';
 const fetchOkResult = Result.from(async () => fetchRemoteData());
 
 class FetchFailedError extends Error {
-  name = 'FetchFailedError' as const;
+  private __brand!: never;
 }
 
 const fetchDataOrErrorResult = Result.from(async () => {
@@ -433,7 +438,7 @@ It modifies the return type of any given function, synchronous or asynchronous, 
 import { Result, Err, resultify } from 'type-safe-errors';
 
 class FetchFailedError extends Error {
-  name = "FetchFailedError" as const;
+  private __brand!: never;
 }
 
 async function fetchDataOrErrorResult () {
@@ -478,7 +483,7 @@ Err<TErr>.map<unknown>(callback: (value: never) => never): Err<TErr>;
 import { Ok, Err } from 'type-safe-errors';
 
 class UserNotFoundError extends Error {
-  name = "UserNotFoundError" as const;
+  private __brand!: never;
 }
 
 const okOfNumber5 = Ok.of(10).map(value => value / 2);

--- a/examples/basic-example/types.ts
+++ b/examples/basic-example/types.ts
@@ -10,9 +10,9 @@ interface Product {
 }
 
 class InvalidCVCError extends Error {
-  name = 'InvalidCVCError' as const;
+  private __brand!: never;
 }
 
 class MissingPriceError extends Error {
-  name = 'MissingPriceError' as const;
+  private __brand!: never;
 }

--- a/examples/express/errors.ts
+++ b/examples/express/errors.ts
@@ -1,13 +1,13 @@
 export { InvalidCVCError, UknownProductError, MissingCardNumberError };
 
 class InvalidCVCError extends Error {
-  name = 'InvalidCVCError' as const;
+  private __brand!: never;
 }
 
 class UknownProductError extends Error {
-  name = 'UknownProductError' as const;
+  private __brand!: never;
 }
 
 class MissingCardNumberError extends Error {
-  name = 'MissingCardNumberError' as const;
+  private __brand!: never;
 }

--- a/examples/fastify/errors.ts
+++ b/examples/fastify/errors.ts
@@ -1,13 +1,13 @@
 export { InvalidCVCError, UknownProductError, MissingCardNumberError };
 
 class InvalidCVCError extends Error {
-  name = 'InvalidCVCError' as const;
+  private __brand!: never;
 }
 
 class UknownProductError extends Error {
-  name = 'UknownProductError' as const;
+  private __brand!: never;
 }
 
 class MissingCardNumberError extends Error {
-  name = 'MissingCardNumberError' as const;
+  private __brand!: never;
 }

--- a/examples/nestjs/pay/errors.ts
+++ b/examples/nestjs/pay/errors.ts
@@ -1,13 +1,13 @@
 export { InvalidCVCError, UknownProductError, MissingCardNumberError };
 
 class InvalidCVCError extends Error {
-  name = 'InvalidCVCError' as const;
+  private __brand!: never;
 }
 
 class UknownProductError extends Error {
-  name = 'UknownProductError' as const;
+  private __brand!: never;
 }
 
 class MissingCardNumberError extends Error {
-  name = 'MissingCardNumberError' as const;
+  private __brand!: never;
 }

--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -6,13 +6,13 @@ import {
 } from './helper';
 
 class Error1 extends Error {
-  name = 'Error1' as const;
+  private __brand!: never;
 }
 class Error2 extends Error {
-  name = 'Error2' as const;
+  private __brand!: never;
 }
 class Error3 extends Error {
-  name = 'Error3' as const;
+  private __brand!: never;
 }
 
 test('Result combine of two Ok values result returns Ok result of array of two values', (done) => {

--- a/src/test/map.test.ts
+++ b/src/test/map.test.ts
@@ -9,13 +9,15 @@ import {
 } from './helper';
 
 class Error1 extends Error {
-  name = 'Error1' as const;
+  private __brand!: never;
 }
+
 class Error2 extends Error {
-  name = 'Error2' as const;
+  private __brand!: never;
 }
+
 class Error3 extends Error {
-  name = 'Error3' as const;
+  private __brand!: never;
 }
 
 /**

--- a/src/test/promise.test.ts
+++ b/src/test/promise.test.ts
@@ -2,7 +2,7 @@ import { expect, assert } from 'chai';
 import { Ok, Err } from '../index';
 
 class Error1 extends Error {
-  name = 'Error1' as const;
+  private __brand!: never;
 }
 
 test('Result of an Ok value map to a promise of the value', async () => {

--- a/src/test/result-from.test.ts
+++ b/src/test/result-from.test.ts
@@ -6,8 +6,8 @@ import {
   shouldEventuallyUnknownErr,
 } from './helper';
 
-class Error1 {
-  name = 'Error1' as const;
+class Error1 extends Error {
+  private __brand!: never;
 }
 
 suite('Result.from of an result factory', () => {

--- a/src/test/resultify.test.ts
+++ b/src/test/resultify.test.ts
@@ -7,7 +7,7 @@ import {
 } from './helper';
 
 class Error2 extends Error {
-  name = 'Error2' as const;
+  private __brand!: never;
 }
 
 suite('resultify of a sync function', () => {


### PR DESCRIPTION
Old type branding strategy require unique name for the type. In big projects with hunderds of errors, it was easy to reuse the same name in few types and the confuse classes.

Typescript was blind for such issues.