### PR TITLE
Fix mixed sync/async callback results typings

### DIFF
--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -96,6 +96,28 @@ test('Result combine of mixed types per Result and Result promises returns expec
   );
 });
 
+test('Result combine of mixed types per Result and following map should include all errors', (done) => {
+  const mixedResults = [
+    Ok.of('return-type') as Err<Error1> | Ok<'return-type'>,
+  ];
+
+  const asyncFun = () => {
+    return Promise.resolve(123 as const);
+  };
+
+  const mapped: Result<123, Error1 | Error2> = Result.combine(mixedResults)
+    .map(() => {
+      if (Math.random()) {
+        return Err.of(new Error2());
+      }
+
+      return asyncFun();
+    })
+    .mapErr(Error2, () => 123 as const);
+
+  shouldEventuallyOk(mapped, 123, done);
+});
+
 test('Result.combine of results with possibly undefined values preserves possibly undefined values', (done) => {
   const result = Result.combine([
     Ok.of<string | undefined>(undefined),

--- a/src/test/combine.test.ts
+++ b/src/test/combine.test.ts
@@ -96,7 +96,7 @@ test('Result combine of mixed types per Result and Result promises returns expec
   );
 });
 
-test('Result combine of mixed types per Result and following map should include all errors', (done) => {
+test('Result combine of mixed types per Result and following map of mixed sync/async results should include all errors', (done) => {
   const mixedResults = [
     Ok.of('return-type') as Err<Error1> | Ok<'return-type'>,
   ];

--- a/src/types/common-result.ts
+++ b/src/types/common-result.ts
@@ -19,8 +19,8 @@ interface CommonResult<TErrorOrValue> {
 
   map<U extends Result<unknown, unknown>, R>(
     this: U,
-    mapper: (value: InferOk<U>) => R | Promise<R>
-  ): MapOkResult<U, R>;
+    mapper: (value: InferOk<U>) => R
+  ): MapOkResult<U, Awaited<R>>;
 
   mapErr<
     U extends Result<unknown, unknown>,
@@ -29,8 +29,8 @@ interface CommonResult<TErrorOrValue> {
   >(
     this: U,
     ErrorClass: Constructor<E>,
-    mapper: (err: E) => R | Promise<R>
-  ): MapErrResult<U, R, E>;
+    mapper: (err: E) => R
+  ): MapErrResult<U, Awaited<R>, E>;
 
   mapAnyErr<U extends Result<unknown, unknown>, R>(
     this: U,

--- a/src/types/result-helpers.ts
+++ b/src/types/result-helpers.ts
@@ -54,8 +54,8 @@ interface Subresult {
    */
   map<U extends Result<unknown, unknown>, R>(
     this: U,
-    mapper: (value: InferOk<U>) => R | Promise<R>
-  ): MapOkResult<U, R>;
+    mapper: (value: InferOk<U>) => R
+  ): MapOkResult<U, Awaited<R>>;
 
   /**
    * Map current Result if it's a Err of a specific class.
@@ -72,8 +72,8 @@ interface Subresult {
   >(
     this: U,
     ErrorClass: Constructor<E>,
-    mapper: (err: E) => R | Promise<R>
-  ): MapErrResult<U, R, E>;
+    mapper: (err: E) => R
+  ): MapErrResult<U, Awaited<R>, E>;
 
   /**
    * Map current Result if it's Err. It's left Ok Result unchanged.


### PR DESCRIPTION
Fix bug in types when async and sync results has been mixed in map callback, e.g.


```ts

  const asyncFun = () => {
    return Promise.resolve(123 as const);
  };

  const mapped: Result<123, Error1 | Error2> = Result.combine(mixedResults)
    .map(() => {
      if (Math.random()) {
        return Err.of(new Error2());
      }

      return asyncFun();
    })
```

This gave a typescript error before this change.